### PR TITLE
DM-34458: Add sample notebooks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 LSST SQuaRE
+Copyright (c) 2022 Association of Universities for Research in Astronomy, Inc. (AURA)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # times-square-demo
-Demo notebook repository for the Times Square RSP service
+
+Demo notebook repository for the [Times Square](https://github.com/lsst-sqre/times-square) RSP service.

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "62ba73ba-a282-4436-903e-65b630d7f3bd",
+   "metadata": {},
+   "source": [
+    "# Times Square demo\n",
+    "\n",
+    "Plot parameters:\n",
+    "\n",
+    "- Amplitude: A = {{ params.A }}\n",
+    "- Y offset: y0 = {{ params.y0 }}\n",
+    "- Wavelength: lambd = {{ params.lambda }}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46aeb19e-52e3-48c6-9f8a-430a0189f34a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "plt.style.use('seaborn-bright')\n",
+    "\n",
+    "\n",
+    "def plot(y0, A, lambd):\n",
+    "    x = np.linspace(0, 10, 100)\n",
+    "    y = y0 + A * np.sin(2 * np.pi * x / lambd)\n",
+    "\n",
+    "    # plot\n",
+    "    fig, ax = plt.subplots()\n",
+    "\n",
+    "    ax.plot(x, y, linewidth=2.0)\n",
+    "\n",
+    "    ax.set(\n",
+    "        xlim=(0, 8), xticks=np.arange(1, 8),\n",
+    "        ylim=(0, 8), yticks=np.arange(1, 8)\n",
+    "    )\n",
+    "\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4e5b310c-65ce-4855-b4fd-3426c12a3991",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot({{ params.y0 }}, {{ params.A }}, {{ params.lambda }})"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/demo.yaml
+++ b/demo.yaml
@@ -1,0 +1,18 @@
+parameters:
+  A:
+    type: number
+    description: Amplitude
+    default: 4
+    minimum: 0
+  lambda:
+    type: number
+    description: Wavelength
+    default: 2
+    minimum: 0
+  y0:
+    type: number
+    description: Y-axis offset
+    default: 0
+authors:
+  - name: Jonathan Sick
+    slack: jonathansick

--- a/matplotlib/gaussian2d.ipynb
+++ b/matplotlib/gaussian2d.ipynb
@@ -1,0 +1,106 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a6bfe7b6-e66c-4562-9edb-b5d22b0f05ec",
+   "metadata": {},
+   "source": [
+    "# 2D Guassian\n",
+    "\n",
+    "This demonstration is from the [Matplotlib example gallery.](https://matplotlib.org/stable/gallery/lines_bars_and_markers/scatter_hist.html). You can control the distribution's standard deviation and origin."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9df7fe06-413e-423a-9b90-1c9962410fe8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# Fixing random state for reproducibility\n",
+    "np.random.seed(19680801)\n",
+    "\n",
+    "# some random data\n",
+    "x = {{ params.sigma_x }} * np.random.randn(1000) + {{ params.x_0 }}\n",
+    "y = {{ params.sigma_y }} * np.random.randn(1000) + {{ params.y_0 }}\n",
+    "\n",
+    "\n",
+    "def scatter_hist(x, y, ax, ax_histx, ax_histy):\n",
+    "    # no labels\n",
+    "    ax_histx.tick_params(axis=\"x\", labelbottom=False)\n",
+    "    ax_histy.tick_params(axis=\"y\", labelleft=False)\n",
+    "\n",
+    "    # the scatter plot:\n",
+    "    ax.scatter(x, y)\n",
+    "\n",
+    "    # now determine nice limits by hand:\n",
+    "    binwidth = 0.25\n",
+    "    xymax = max(np.max(np.abs(x)), np.max(np.abs(y)))\n",
+    "    lim = (int(xymax/binwidth) + 1) * binwidth\n",
+    "\n",
+    "    bins = np.arange(-lim, lim + binwidth, binwidth)\n",
+    "    ax_histx.hist(x, bins=bins)\n",
+    "    ax_histy.hist(y, bins=bins, orientation='horizontal')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb5b3c94-5f39-469f-96e4-fa603af20166",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# start with a square Figure\n",
+    "fig = plt.figure(figsize=(8, 8))\n",
+    "\n",
+    "# Add a gridspec with two rows and two columns and a ratio of 2 to 7 between\n",
+    "# the size of the marginal axes and the main axes in both directions.\n",
+    "# Also adjust the subplot parameters for a square plot.\n",
+    "gs = fig.add_gridspec(2, 2,  width_ratios=(7, 2), height_ratios=(2, 7),\n",
+    "                      left=0.1, right=0.9, bottom=0.1, top=0.9,\n",
+    "                      wspace=0.05, hspace=0.05)\n",
+    "\n",
+    "ax = fig.add_subplot(gs[1, 0])\n",
+    "ax_histx = fig.add_subplot(gs[0, 0], sharex=ax)\n",
+    "ax_histy = fig.add_subplot(gs[1, 1], sharey=ax)\n",
+    "\n",
+    "# use the previously defined function\n",
+    "scatter_hist(x, y, ax, ax_histx, ax_histy)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4bf6dac-1ff8-451e-a926-2acacb11066a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/matplotlib/gaussian2d.yaml
+++ b/matplotlib/gaussian2d.yaml
@@ -1,0 +1,20 @@
+title: Gaussian 2D
+parameters:
+  sigma_x:
+    type: number
+    description: X-axis standard deviation
+    default: 1
+    minimum: 0
+  sigma_y:
+    type: number
+    description: Y-axis standard deviation
+    default: 1
+    minimum: 0
+  x_0:
+    type: number
+    description: X-axis offset
+    default: 0
+  y_0:
+    type: number
+    description: Y-axis offset
+    default: 0

--- a/times-square.yaml
+++ b/times-square.yaml
@@ -1,0 +1,4 @@
+enabled: true
+title: Demo
+description: >
+  These notebooks demonstrate Times Square's capabilities.


### PR DESCRIPTION
This seeds the demo repo for [times-square](https://github.com/lsst-sqre/) development. There are two notebooks so far:

- demo - this is the existing sin-wave demo
- matplotlib/gaussian2d - based on https://matplotlib.org/stable/gallery/lines_bars_and_markers/scatter_hist.html