### PR TITLE
Update notebooks to use first code cell for params

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -17,6 +17,20 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "d9393bc6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set parameters for testing\n",
+    "# This code cell will be replaced by Times Square\n",
+    "A = 1.\n",
+    "y0 = 4.\n",
+    "lamb = 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "46aeb19e-52e3-48c6-9f8a-430a0189f34a",
    "metadata": {
     "tags": []
@@ -53,16 +67,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot({{ params.y0 }}, {{ params.A }}, {{ params.lambda }})"
+    "plot(y0, A, lamb)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "977ece69-8f79-4eda-9d32-1456c776eafc",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/demo.ipynb
+++ b/demo.ipynb
@@ -11,7 +11,7 @@
     "\n",
     "- Amplitude: A = {{ params.A }}\n",
     "- Y offset: y0 = {{ params.y0 }}\n",
-    "- Wavelength: lambd = {{ params.lambda }}"
+    "- Wavelength: lamb = {{ params.lamb }}"
    ]
   },
   {
@@ -23,9 +23,9 @@
    "source": [
     "# Set parameters for testing\n",
     "# This code cell will be replaced by Times Square\n",
-    "A = 1.\n",
-    "y0 = 4.\n",
-    "lamb = 1."
+    "A = 1.0\n",
+    "y0 = 4.0\n",
+    "lamb = 1.0"
    ]
   },
   {

--- a/demo.yaml
+++ b/demo.yaml
@@ -11,7 +11,7 @@ parameters:
     description: Amplitude
     default: 2
     minimum: 0
-  lambda:
+  lamb:
     type: number
     description: Wavelength
     default: 1

--- a/matplotlib/gaussian2d.ipynb
+++ b/matplotlib/gaussian2d.ipynb
@@ -13,6 +13,21 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a96c1110",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set parameters for testing\n",
+    "# This code cell will be replaced by Times Square\n",
+    "x_0 = 0.0\n",
+    "y_0 = 0.0\n",
+    "sigma_x = 1.0\n",
+    "sigma_y = 1.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "9df7fe06-413e-423a-9b90-1c9962410fe8",
    "metadata": {
     "tags": []
@@ -26,8 +41,8 @@
     "np.random.seed(19680801)\n",
     "\n",
     "# some random data\n",
-    "x = {{ params.sigma_x }} * np.random.randn(1000) + {{ params.x_0 }}\n",
-    "y = {{ params.sigma_y }} * np.random.randn(1000) + {{ params.y_0 }}\n",
+    "x = sigma_x * np.random.randn(1000) + x_0\n",
+    "y = sigma_y * np.random.randn(1000) + y_0\n",
     "\n",
     "def scatter_hist(x, y, ax, ax_histx, ax_histy):\n",
     "    # no labels\n",
@@ -75,14 +90,6 @@
     "\n",
     "plt.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c4bf6dac-1ff8-451e-a926-2acacb11066a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This is the new behaviour in Times Square 0.9.